### PR TITLE
Add note for Fiefox users

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This is a browser extension (works in Chrome, Firefox, and Chrome-like browsers)
 
 > **⚠️ Note:** At the moment, the changes required for this extension to work are not yet merged into the stable release of ArchiveBox, so you will need to run the `dev` branch by following the steps [outlined here](https://github.com/ArchiveBox/ArchiveBox#install-and-run-a-specific-github-branch).
 
+> **⚠️ Note for Firefox Users:** Firefoxs' default behaviour seems to block a permission request to access all pages, so you can not send pages to archivebox. You may have to manually enable it in `about:addons > ArchiveBox Exporter > Manage > Permissions` and enable the option `Access your data for all websites`.
+
 ## Features
 
 - Different archive modes


### PR DESCRIPTION
I tested the default behavior of a vanilla Firefox browser and it seems that Firefox blocks all request for additional permissions after the install of the add-on when you try to right click a page and send it to archive box.

See: 
![image](https://user-images.githubusercontent.com/38333220/138276360-ab65d467-9055-42c5-9c44-297a8b752a1d.png)

This was also mentioned in #11

Added a note for Firefox users, how to manually set the permissions for the extension.